### PR TITLE
Remove distribution management config in order to use EE4J parent config

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -72,17 +72,6 @@
         </mailingList>
     </mailingLists>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <properties>
         <api_package>javax.mvc</api_package>
         <spec_version>1.1</spec_version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,17 +53,6 @@
         <developerConnection>scm:git:https://github.com/eclipse-ee4j/mvc-api.git</developerConnection>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
Signed-off-by: Ivar Grimstad <ivar.grimstad@eclipse-foundation.org>