### PR TITLE
Some cleanup for the Maven build

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,10 +34,6 @@
     </parent>
 
     <properties>
-        <api_package>javax.mvc</api_package>
-        <spec_version>1.1</spec_version>
-        <spec_impl_version>${project.version}</spec_impl_version>
-        <packages.export>javax.mvc.*</packages.export>
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 
@@ -50,13 +46,13 @@
                 <configuration>
                     <specMode>jakarta</specMode>
                     <spec>
-                        <nonFinal>true</nonFinal>
+                        <nonFinal>${spec.nonFinal}</nonFinal>
                         <jarType>api</jarType>
                         <specVersion>1.0</specVersion>
-                        <newSpecVersion>${spec_version}</newSpecVersion>
+                        <newSpecVersion>${spec.version}</newSpecVersion>
                         <specBuild>01</specBuild>
-                        <specImplVersion>${spec_impl_version}</specImplVersion>
-                        <apiPackage>${api_package}</apiPackage>
+                        <specImplVersion>${project.version}</specImplVersion>
+                        <apiPackage>javax.mvc</apiPackage>
                     </spec>
                 </configuration>
                 <executions>
@@ -187,7 +183,7 @@
                         <Extension-Name>${spec.extension.name}</Extension-Name>
                         <Implementation-Version>${spec.implementation.version}</Implementation-Version>
                         <Specification-Version>${spec.specification.version}</Specification-Version>
-                        <Export-Package>${packages.export}</Export-Package>
+                        <Export-Package>javax.mvc.*</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,74 +19,26 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>jakarta.mvc</groupId>
+
     <artifactId>jakarta.mvc-api</artifactId>
-    <version>1.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Jakarta MVC API</name>
     <description>Jakarta MVC API</description>
     <url>https://www.mvc-spec.org/</url>
 
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.6</version>
-        <relativePath/>
+        <groupId>jakarta.mvc</groupId>
+        <artifactId>jakarta.mvc-parent</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
-
-    <organization>
-        <name>Eclipse Foundation</name>
-        <url>https://www.eclipse.org/org/foundation/</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>EPL-2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>GPL-2.0-with-classpath-exception</name>
-            <url>https://www.gnu.org/software/classpath/license.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>ivargrimstad</id>
-            <email>ivar.grimstad@gmail.com</email>
-            <name>Ivar Grimstad</name>
-            <timezone>CET</timezone>
-        </developer>
-        <developer>
-            <id>chkal</id>
-            <email>christian@kaltepoth.de</email>
-            <name>Christian Kaltepoth</name>
-            <timezone>CET</timezone>
-        </developer>
-    </developers>
-
-    <issueManagement>
-        <system>github</system>
-        <url>https://github.com/eclipse-ee4j/mvc-api/issues</url>
-    </issueManagement>
-
-    <mailingLists>
-        <mailingList>
-            <name>Jakarta MVC Devloper Mailing List</name>
-            <archive>https://accounts.eclipse.org/mailing-list/mvc-dev</archive>
-        </mailingList>
-    </mailingLists>
 
     <properties>
         <api_package>javax.mvc</api_package>
         <spec_version>1.1</spec_version>
         <spec_impl_version>${project.version}</spec_impl_version>
         <packages.export>javax.mvc.*</packages.export>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 
     <build>
@@ -388,9 +340,4 @@
             </plugin>        
         </plugins>
     </reporting>
-    <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/mvc-api.git</connection>
-        <developerConnection>scm:git:https://github.com/eclipse-ee4j/mvc-api.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/mvc-api</url>
-    </scm>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>jakarta.mvc</groupId>
         <artifactId>jakarta.mvc-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,8 +23,8 @@
     <artifactId>jakarta.mvc-api</artifactId>
     <version>1.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
-    <name>Jakarta MVC ${project.version} API</name>
-    <description>Jakarta MVC ${project.version} API</description>
+    <name>Jakarta MVC API</name>
+    <description>Jakarta MVC API</description>
     <url>https://www.mvc-spec.org/</url>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <spec.version>1.1</spec.version>
+        <spec.nonFinal>true</spec.nonFinal>
+        <spec.status>Draft</spec.status>  <!-- Empty for final version -->
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
     <artifactId>jakarta.mvc-parent</artifactId>
     <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Jakarta MVC ${project.version} Parent</name>
+    <name>Jakarta MVC Parent</name>
+    <description>Jakarta MVC Parent</description>
     <url>https://www.mvc-spec.org/</url>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,32 @@
         <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/mvc-api.git</developerConnection>
     </scm>
 
+    <licenses>
+        <license>
+            <name>EPL-2.0</name>
+            <url>http://www.eclipse.org/legal/epl-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>GPL-2.0-with-classpath-exception</name>
+            <url>https://www.gnu.org/software/classpath/license.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>developers</id>
+            <name>Jakarta MVC Team</name>
+            <email>mvc-dev@eclipse.org</email>
+            <url>https://projects.eclipse.org/projects/ee4j.mvc/who</url>
+        </developer>
+    </developers>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.mvc</groupId>
     <artifactId>jakarta.mvc-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta MVC Parent</name>
     <description>Jakarta MVC Parent</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -34,6 +34,8 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
+        <revisiondate>${maven.build.timestamp}</revisiondate>
     </properties>
 
     <build>
@@ -63,6 +65,9 @@
                                 <toc/>
                                 <linkcss>false</linkcss>
                                 <project-version>${project.version}</project-version>
+                                <revnumber>${spec.version}</revnumber>
+                                <revremark>${spec.status}</revremark>
+                                <revdate>${revisiondate}</revdate>
                             </attributes>
                             <outputFile>${project.build.directory}/generated-docs/index.html</outputFile>
                         </configuration>
@@ -86,6 +91,9 @@
                                 <docinfo>true</docinfo>
                                 <experimental>false</experimental>
                                 <toc>true</toc>
+                                <revnumber>${spec.version}</revnumber>
+                                <revremark>${spec.status}</revremark>
+                                <revdate>${revisiondate}</revdate>
                             </attributes>
                         </configuration>
                     </execution>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -18,40 +18,21 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>jakarta.mvc</groupId>
+
     <artifactId>jakarta.mvc-spec</artifactId>
-    <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta MVC Spec</name>
     <description>Jakarta MVC Spec</description>
     <url>https://www.mvc-spec.org/</url>
- 
-     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.6</version>
-        <relativePath/>
+
+    <parent>
+        <groupId>jakarta.mvc</groupId>
+        <artifactId>jakarta.mvc-parent</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <organization>
-        <name>Eclipse Foundation</name>
-        <url>https://www.eclipse.org/org/foundation/</url>
-    </organization>
-    
-    <issueManagement>
-        <system>github</system>
-        <url>https://github.com/eclipse-ee4j/mvc-api/issues</url>
-    </issueManagement>
-
-    <mailingLists>
-        <mailingList>
-            <name>Jakarta MVC Devloper Mailing List</name>
-            <archive>https://accounts.eclipse.org/mailing-list/mvc-dev</archive>
-        </mailingList>
-    </mailingLists>
-
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -22,7 +22,8 @@
     <artifactId>jakarta.mvc-spec</artifactId>
     <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Jakarta MVC ${project.version} Spec</name>
+    <name>Jakarta MVC Spec</name>
+    <description>Jakarta MVC Spec</description>
     <url>https://www.mvc-spec.org/</url>
  
      <parent>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>jakarta.mvc</groupId>
         <artifactId>jakarta.mvc-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -18,7 +18,7 @@ Release: {revdate}
 [[Copyright]]
 === Copyright
 
-Copyright (c) 2018,2020 Eclipse Foundation.
+Copyright (c) 2018, 2020 Eclipse Foundation.
 
 [[efsl]]
 === Eclipse Foundation Specification License
@@ -38,7 +38,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
   of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php[]"
+  Eclipse Foundation, Inc. \<<url to this license>>"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -57,9 +57,9 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2018,2020 Eclipse Foundation. This software or
-document includes material copied from or derived from 
-Jakarta EE Platform Specification, https://jakarta.ee/specifications/platform/9/[]."
+"Copyright (c) [$date-of-document] Eclipse Foundation. This software or
+document includes material copied from or derived from [title and URI
+of the Eclipse Foundation specification document]."
 
 [[disclaimers]]
 ==== Disclaimers


### PR DESCRIPTION
Hi all,

I spent some time today to review and cleanup the spec project. The PR contains the following changes. Each change is a separate commit. I hope that this simplifies the review:

- I removed the version from the Maven module name, as this had some weird effects.
- The spec and API modules now use the MVC parent module as a parent. IMO this is much better, because we can declare much stuff in the parent without having to duplicate it to both modules.
- I reverted some changes done to `license-efsl.adoc`. For some reason we need to keep the placeholders as they were. See Kevin's comments on the mailing list for details.
- I cleaned up a few Maven properties by giving them better names, inlining others which were only used in a single place and even created two new ones. We also now pass all the required AsciiDoc attributes to the spec documents so that all placeholders are replaced.
- I updated the version from `1.1-SNAPSHOT` to `1.1.0-SNAPSHOT`. IMO we should use semver as most other spec projects do it.

Happy to hear your thoughts. :-)


