### PR TITLE
Some more minor cleanup

### DIFF
--- a/spec/src/main/asciidoc/chapters/controllers.asciidoc
+++ b/spec/src/main/asciidoc/chapters/controllers.asciidoc
@@ -9,7 +9,7 @@ This chapter introduces the three components that comprise the
 Controllers
 ~~~~~~~~~~~
 
-[tck-testable tck-id-ctrl-method]#A _Jakarta MVC controller_ is a Jakarta RESTful Web Services [<<jaxrs20,5>>] resource method decorated by `@Controller`#.
+[tck-testable tck-id-ctrl-method]#A _Jakarta MVC controller_ is a Jakarta RESTful Web Services [<<jaxrs21,5>>] resource method decorated by `@Controller`#.
 [tck-testable tck-id-ctrl-class]#If this annotation is applied to a class, then all resource methods in it are regarded as controllers#.
 [tck-testable tck-id-ctrl-hybrid]#Using the `@Controller` annotation on a subset of methods defines a hybrid class in which certain methods are controllers and others are traditional Jakarta RESTful Web Services resource methods.#
 
@@ -75,7 +75,7 @@ i.e.,
 [tck-testable tck-id-inject-field-props]#Likewise, injection of fields and properties is unrestricted and fully compatible with Jakarta RESTful Web Services#.
 Note the restrictions explained in Section <<controller_instances>>.
 
-Controller methods handle a HTTP request directly. Sub-resource locators as described in the Jakarta RESTful Web Services Specification [<<jaxrs20,5>>] are not supported by Jakarta MVC.
+Controller methods handle a HTTP request directly. Sub-resource locators as described in the Jakarta RESTful Web Services Specification [<<jaxrs21,5>>] are not supported by Jakarta MVC.
 
 [[controller_instances]]
 Controller Instances
@@ -88,7 +88,7 @@ Unlike in Jakarta RESTful Web Services where resource classes can be native (cr
 [tck-testable tck-id-request-scope-default]#Like in Jakarta RESTful Web Services, the default resource class instance lifecycle is _per-request_#.
 Implementations MAY support other lifecycles via CDI; the same caveats that apply to Jakarta RESTful Web Services classes in other lifecycles applied to Jakarta MVC classes.
 [tck-testable tck-id-scope-proxy]#In particular, CDI may need to create proxies when, for example, a per-request instance is as a member of a per-application instance#.
-See [<<jaxrs20,5>>] for more information on lifecycles and their caveats.
+See [<<jaxrs21,5>>] for more information on lifecycles and their caveats.
 
 [[response]]
 Response

--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -52,11 +52,11 @@ https://github.com/eclipse-ee4j/mvc-api/issues
 
 The corresponding Javadocs can be found online at:
 
-https://www.mvc-spec.org/spec/
+https://jakarta.ee/specifications/mvc/1.1/apidocs/
 
 A compatible implementation can be obtained from:
 
-https://www.mvc-spec.org/krazo/
+https://projects.eclipse.org/projects/ee4j.krazo
 
 The project team seeks feedback from the community on any aspect of this specification, please send comments to:
 

--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -54,7 +54,7 @@ The corresponding Javadocs can be found online at:
 
 https://www.mvc-spec.org/spec/
 
-The reference implementation can be obtained from:
+A compatible implementation can be obtained from:
 
 https://www.mvc-spec.org/krazo/
 

--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -109,12 +109,13 @@ guidance provided by the Jakarta EE Working Group (https://jakarta.ee/).
 Acknowledgements for version 1.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Version 1.0 was developed as part of https://jcp.org/en/jsr/detail?id=371[JSR 371] under the Java Community Process.
+
 [[spec_leads]]
 Specification Leads
 ^^^^^^^^^^^^^^^^^^^
 
-
-The following table lists the current and former specification leads:
+The following table lists the specification leads of the JSR:
 
 [cols="1,1"]
 |===
@@ -128,7 +129,7 @@ The following table lists the current and former specification leads:
 Expert Group Members
 ^^^^^^^^^^^^^^^^^^^^
 
-This specification is being developed as part of https://jcp.org/en/jsr/detail?id=371[JSR 371] under the Java Community Process. The following are the present expert group members:
+The following were the expert group members:
 
 [cols="1,1"] 
 |===
@@ -148,7 +149,7 @@ This specification is being developed as part of https://jcp.org/en/jsr/detail?i
 |Manfred Riem (Oracle)
 |===
 
-The following are former members of the expert group:
+The following were former members of the expert group:
 
 [cols="1,1"] 
 |===
@@ -160,7 +161,7 @@ The following are former members of the expert group:
 Contributors
 ^^^^^^^^^^^^
 
-The following are the contributors of the specification:
+The following were the contributors of the specification:
 
 [cols="1,1"]
 |===
@@ -170,5 +171,5 @@ The following are the contributors of the specification:
 |
 |===
 
-During the course of this JSR we received many excellent suggestions. Special thanks to Marek Potociar, Dhiru Pandey and Ed Burns, all from Oracle. 
+During the course of this JSR we received many excellent suggestions. Special thanks to Marek Potociar, Dhiru Pandey and Ed Burns, all from Oracle.
 In addition, to everyone in the user’s alias that followed the expert discussions and provided feedback, including Peter Pilgrim, Ivar Grimstad, Jozef Hartinger, Florian Hirsch, Frans Tamura, Rahman Usta, Romain Manni-Bucau, Alberto Souza, among many others.

--- a/spec/src/main/asciidoc/chapters/intro.asciidoc
+++ b/spec/src/main/asciidoc/chapters/intro.asciidoc
@@ -12,7 +12,7 @@ typically handled by framework components with little or no interaction from app
 the majority of the controller logic is provided by the framework instead of the application.
 
 The API defined by this specification falls into the action-based category and is, therefore, not intended to be a replacement for
-component-based frameworks such as Jakarta Server Faces [<<jsf22,1>>], but simply a different approach to building Web applications on the Jakarta EE platform.
+component-based frameworks such as Jakarta Server Faces [<<jsf23,1>>], but simply a different approach to building Web applications on the Jakarta EE platform.
 
 [[goals]]
 Goals
@@ -21,7 +21,7 @@ Goals
 The following are goals of the API:
 
 [horizontal]
-Goal 1:: Leverage existing Jakarta EE technologies like Jakarta Contexs and Dependency Injecttion [<<cdi11,2>>] and Jakarta Bean Validation [<<bv11,3>>].
+Goal 1:: Leverage existing Jakarta EE technologies like Jakarta Contexs and Dependency Injecttion [<<cdi20,2>>] and Jakarta Bean Validation [<<bv20,3>>].
 Goal 2:: Define a solid core to build MVC applications without necessarily supporting all the features in its first version.
 Goal 3:: Build on top of Jakarta RESTful Web Services for the purpose of re-using its matching and binding layers.
 Goal 4:: Provide built-in support for Jakarta Server Pages and Facelets view languages.

--- a/spec/src/main/asciidoc/chapters/refs.asciidoc
+++ b/spec/src/main/asciidoc/chapters/refs.asciidoc
@@ -5,26 +5,26 @@
 
 == Bibliography
 
-[[jsf22]] 
-[1]:: Edward Burns. JavaServer Faces 2.2. JSR, JCP, May 2013 +
-http://jcp.org/en/jsr/detail?id=344
+[[jsf23]]
+[1]:: Jakarta Server Faces 2.3, August 2019 +
+https://jakarta.ee/specifications/faces/2.3/
 
-[[cdi11]]
-[2]:: Pete Muir. Context and Dependency Injection for Java EE 1.1 MR. JSR, JCP, April 2014 +
-http://jcp.org/en/jsr/detail?id=346
+[[cdi20]]
+[2]:: Jakarta Context Dependency Injection 2.0, August 2019 +
+https://jakarta.ee/specifications/cdi/2.0/
 
-[[bv11]]
-[3]:: Emmanuel Bernard. Bean Validation 1.1. JSR, JCP, March 2013 +
-http://jcp.org/en/jsr/detail?id=349
+[[bv20]]
+[3]:: Jakarta Bean Validation 2.0, August 2019 +
+https://jakarta.ee/specifications/bean-validation/2.0/
 
 [[rfc2119]]
 [4]:: S. Bradner. RFC 2119: Keywords for use in RFCs to Indicate Requirement Levels. RFC, IETF, March 1997 + 
 http://www.ietf.org/rfc/rfc2119.txt
 
-[[jaxrs20]]
-[5]:: Santiago Pericas-Geertsen and Marek Potociar. The Java API for RESTful Web Services 2.0 MR. JSR, JCP, October 2014 +
-http://jcp.org/en/jsr/detail?id=339
+[[jaxrs21]]
+[5]:: Jakarta RESTful Web Services 2.1, August 2019 +
+https://jakarta.ee/specifications/restful-ws/2.1/
 
 [[el30]]
-[6]:: Kin man Chung. Expression Language 3.0. JSR, JCP, May 2013 +
-http://jcp.org/en/jsr/detail?id=341
+[6]:: Jakarta Expression Language 3.0, August 2019 +
+https://jakarta.ee/specifications/expression-language/3.0/

--- a/spec/src/main/xsl/tck-audit.xsl
+++ b/spec/src/main/xsl/tck-audit.xsl
@@ -158,7 +158,7 @@
         <xsl:text>&#10;</xsl:text>
 
         <specification xmlns="http://jboss.com/products/weld/tck/audit" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://jboss.com/products/weld/tck/audit" name="JSR-371: MVC 1.0" version="1.0" id="mvc" generateSectionIds="true">
+            xsi:schemaLocation="http://jboss.com/products/weld/tck/audit" name="Jakarta MVC Specification" version="1.1" id="mvc" generateSectionIds="true">
 
             <xsl:apply-templates mode="createAuditFile"/>
 


### PR DESCRIPTION
Another pull request with some cleanup. Each change is a separate commit:

- Replaced "reference implementation" with "compatible implementation"
- Replaced mvc-spec.org links with eclipse.org or jakarta.ee links
  - (Please note that I added a link for the javadocs which actutally doesn't exist yet. @ivargrimstad could you double-check that this ok?)
- Replaced JSR references in the bibliography with the Jakarta specification names and links
- The TCK coverage XML document still contained "JSR371" in a name attribute
- Updated the wording in the "1.0 acknowledgments" section to use past tense

Feedback welcome! It would be great if we could merge this one soon so that Ivar and I can work on pushing out 1.1 final really soon.