### PR TITLE
Specify overwrite mechanism for form methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ nbactions.xml
 nb-configuration.xml
 *.iml
 site.zip
+
+.project
+.classpath
+.settings/

--- a/api/src/main/java/jakarta/mvc/form/FormMethodOverwriter.java
+++ b/api/src/main/java/jakarta/mvc/form/FormMethodOverwriter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package jakarta.mvc.form;
+
+/**
+ * <p>Form method overwriter is used to overwrite a HTML form's HTTP method to be able to use
+ * other verbs such as {@code PATCH} or {@code DELETE}.
+ * </p>
+ * 
+ * @author Tobias Erdle
+ * @since 2.1
+ */
+public final class FormMethodOverwriter {
+    
+    /**
+     * Property that can be used to enable the Form method overwrite mechanism for an application.
+     * Values of this property must be of type {@link FormMethodOverwriter.Options}.
+     */
+    public static final String FORM_METHOD_OVERWRITE = "jakarta.mvc.form.FormMethodOverwrite";
+
+    /**
+     * Property that can be used to configure the name of the hidden form input to get the targeted HTTP method.
+     */
+    public static final String HIDDEN_FIELD_NAME = "jakarta.mvc.form.HiddenFieldName";
+    
+    /**
+     * The default name of the hidden form field used to overwrite the HTTP method.
+     */
+    public static final String DEFAULT_HIDDEN_FIELD_NAME = "_method";
+
+    /**
+     * Options for property {@link FormMethodOverwriter#FORM_METHOD_OVERWRITE}.
+     */
+    public enum Options {
+        /**
+         * Form method overwrite is not enabled.
+         */
+        DISABLED,
+
+        /**
+         * Form method overwrite is enabled. Each request will be checked for potential overwrites.
+         */
+        ENABLED
+    }
+}

--- a/api/src/main/java/jakarta/mvc/form/package-info.java
+++ b/api/src/main/java/jakarta/mvc/form/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+/**
+ * This package contains types related to HTML forms.
+ *
+ * @version 2.1
+ */
+package jakarta.mvc.form;

--- a/spec/src/main/asciidoc/chapters/form-method-overwrite.asciidoc
+++ b/spec/src/main/asciidoc/chapters/form-method-overwrite.asciidoc
@@ -1,0 +1,49 @@
+[[form_method_overwrite]]
+Form method override
+--------------------
+
+This chapter introduces the notion of _form method overwrite_ and describes how Jakarta MVC supports HTTP methods besides `GET` and `POST` when using HTML forms.
+
+[[form_method_overwrite_introduction]]
+Introduction
+~~~~~~~~~~~~
+
+The HTML `<form>` is per default only capable of handling the HTTP `GET` and `POST` verbs. Anyway, more complex applications maybe want to use Jakarta MVC to support HTML as one type of resource representation and need the power of other HTTP verbs like `PATCH` or `DELETE` too. Therefore Jakarta MVC supports overwriting the HTTP method by providing an easy to use and configurable mechanism.
+
+Jakarta MVC defines the term _form method overwrite_ as the mechanism being responsible for changing the HTTP request's method to something different than `GET` or `POST`. 
+
+The _form method overwrite_ MUST happen exactly once per request as described in <<form_method_overwrite_resolving_algorithm>> before the controller is resolved.
+
+To have control over the form method handling, Jakarta MVC provides two properties with constants for easier usage in the class `jakarta.mvc.form.FormMethodOverwriter`:
+
+[source,java,numbered]
+----
+include::{mvc-api-source-dir}jakarta/mvc/form/FormMethodOverwriter.java[lines=26..-1]
+----
+
+- `jakarta.mvc.form.FormMethodOverwrite` which can be either `ENABLED` or `DISABLED`. The legal options for this property are defined in `jakarta.mvc.form.FormMethodOverwriter.Options`. Its default value is `ENABLED`.
+- `jakarta.mvc.form.HiddenFieldName` which defines the name of the hidden input field containing the HTTP method which shall be used instead of the original one.
+The default value `_method` is defined in `jakarta.mvc.form.FormMethodOverwriter#HIDDEN_FIELD_NAME_DEFAULT`.
+
+The following sections will explain the form method overwrite resolving algorithm provided by the Jakarta MVC implementation.
+
+[[form_method_overwrite_resolving_algorithm]]
+Resolving Algorithm
+~~~~~~~~~~~~~~~~~~~
+
+The _form method overwriter_ is responsible to detect if the HTTP method shall be overwritten and perform the overwrite if necessary. The specification won't provide an interface for this task, as there are a lot of possibilities provided by the specifications MVC is based on, like `HttpServletFilter` from Jakarta Servlet or Jakarta RESTful's `ContainerRequestFilter`.
+
+[tck-testable tck-id-form-overwriter-algorithm]#Implementations MUST use the following algorithm to overwrite the HTTP method for each request#:
+
+. Check if the following preconditions are `true`:
+.. The configuration property `jakarta.mvc.form.FormMethodOverwrite` is set to `FormMethodOverwriter.Options#ENABLED`
+.. The request is a `POST` request.
+.. A form field with the name like it's configured in `jakarta.mvc.form.HiddenFieldName` is available
+
+. If all conditions are resolved to true:
+.. Overwrite the HTTP method to the value provided by the hidden form field.
+
+. If any of these preconditions evaluates to `false`: 
+.. End the procedure without changing the request's HTTP method
+
+Applications can either rely on the form method overwriter algorithm which is described in this section or provide a custom form method overwriter which implements some other strategy.

--- a/spec/src/main/asciidoc/mvc-spec.asciidoc
+++ b/spec/src/main/asciidoc/mvc-spec.asciidoc
@@ -20,4 +20,6 @@ include::chapters/annotations.asciidoc[]
 
 include::chapters/revision.asciidoc[]
 
+include::chapters/form-method-overwrite.asciidoc[]
+
 include::chapters/refs.asciidoc[]


### PR DESCRIPTION
Hi all,

I just had a little bit of time to begin with the specification of HTML form method overwrites. We already have this mechanism in Krazo, so I used the implementation there as inspiration for the default implementation in the spec. As this is my first addition to the spec, I'm pretty sure there are a lot of things I can do better.

Please let me know what you think about this draft @eclipse-ee4j/ee4j-mvc-committers and anyone else interested.