### PR TITLE
Remove upper version bounds from OSGi Import-Package

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -190,6 +190,10 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                         <Implementation-Version>${spec.implementation.version}</Implementation-Version>
                         <Specification-Version>${spec.specification.version}</Specification-Version>
                         <Export-Package>jakarta.mvc.*</Export-Package>
+
+                        <!-- Use '>=3.0' instead of '[3.0,4)' for 'Import-Package' -->
+                        <_consumer-policy>$${versionmask;==}</_consumer-policy>
+
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Currently, the `maven-bundle-plugin` automatically creates version ranges for the OSGi manifest like this:

```
Import-Package: 
  jakarta.enterprise.context;version="[3.0,4)",
  jakarta.mvc,
  jakarta.mvc.engine,
  jakarta.mvc.security,
  jakarta.validation;version="[3.0,4)",
  jakarta.ws.rs;version="[3.0,4)",
  jakarta.ws.rs.container;version="[3.0,4)",
  jakarta.ws.rs.core;version="[3.0,4)"
```

As @arjantijms pointed out on the mailing list, this is causing issues on Glassfish 7 nightly, as it includes CDI 4.0 which is not compatible with the version range from our manifest.

I therefore adjusted the configuration of the `maven-bundle-plugin` to generate `>=X` instead of `[X,X+1)`. The resulting manifest looks like this:

```
Import-Package: 
  jakarta.enterprise.context;version="3.0",
  jakarta.mvc,
  jakarta.mvc.engine,
  jakarta.mvc.security,
  jakarta.validation;version="3.0",
  jakarta.ws.rs;version="3.0",
  jakarta.ws.rs.container;version="3.0",
  jakarta.ws.rs.core;version="3.0"
```

From my point of view, this is absolutely acceptable.

